### PR TITLE
Update default.rb

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -34,10 +34,10 @@ module Opscode
       # theoretically opens the door for arbitrary kernel_app parameters to be
       # declared.
       kernel.select { |_k, v| !v.nil? }.each_pair do |param, val|
-        rendered << "{#{param}, #{val}}"
+        rendered << "    {#{param}, #{val}}"
       end
 
-      rendered.each { |r| r.prepend('    ') }.join(",\n")
+      rendered.each { |r| r }.join(",\n")
     end
 
     def format_ssl_versions


### PR DESCRIPTION
In Chef 13, the prepend method on the string is failing due to Chef freezing objects.  By moving the extra whitespace characters to the original array, we are able to bypass that frozen object failure which just leaves us with joining the items.